### PR TITLE
Instabug 241

### DIFF
--- a/app/src/main/java/com/flowfoundation/wallet/page/restore/multirestore/fragment/RestoreGoogleDriveFragment.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/restore/multirestore/fragment/RestoreGoogleDriveFragment.kt
@@ -25,6 +25,7 @@ import com.flowfoundation.wallet.base.recyclerview.getItemView
 import com.flowfoundation.wallet.databinding.FragmentRestoreGoogleDriveBinding
 import com.flowfoundation.wallet.manager.backup.ACTION_GOOGLE_DRIVE_RESTORE_FINISH
 import com.flowfoundation.wallet.manager.backup.BackupItem
+import com.flowfoundation.wallet.manager.drive.DriveItem
 import com.flowfoundation.wallet.manager.drive.EXTRA_CONTENT
 import com.flowfoundation.wallet.manager.drive.GoogleDriveAuthActivity
 import com.flowfoundation.wallet.page.restore.multirestore.viewmodel.MultiRestoreViewModel
@@ -42,21 +43,47 @@ class RestoreGoogleDriveFragment: Fragment() {
 
     private val googleDriveRestoreReceiver by lazy {
         object : BroadcastReceiver() {
-            override fun onReceive(context: Context, intent: Intent?) {
-                val data = intent?.getParcelableArrayListExtra<BackupItem>(EXTRA_CONTENT) ?: return
-                if (data.isEmpty()) {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                val driveItems = intent?.getParcelableArrayListExtra<DriveItem>(EXTRA_CONTENT) ?: return
+                if (driveItems.isEmpty()) {
                     onRestoreEmpty()
                 } else {
-                    if (data.size > 1) {
-                        showAccountList(data)
+                    if (driveItems.size > 1) {
+                        val backupItems = driveItems.map { driveItem ->
+                            BackupItem(
+                                address = "", // This will be set later when decrypting
+                                userId = driveItem.uid ?: "",
+                                userAvatar = "", // This will be set later when decrypting
+                                userName = driveItem.username,
+                                publicKey = "", // This will be set later when decrypting
+                                signAlgo = 0, // This will be set later when decrypting
+                                hashAlgo = 0, // This will be set later when decrypting
+                                keyIndex = 0, // This will be set later when decrypting
+                                updateTime = System.currentTimeMillis(),
+                                data = driveItem.data
+                            )
+                        }
+                        showAccountList(backupItems)
                     } else {
-                        val model = data.firstOrNull()
+                        val model = driveItems.firstOrNull()
                         if (model == null) {
                             onRestoreEmpty()
                             return
                         }
-                        restoreViewModel.addWalletInfo(model.userName, model.address)
-                        restoreViewModel.toPinCode(model.data)
+                        val backupItem = BackupItem(
+                            address = "", // This will be set later when decrypting
+                            userId = model.uid ?: "",
+                            userAvatar = "", // This will be set later when decrypting
+                            userName = model.username,
+                            publicKey = "", // This will be set later when decrypting
+                            signAlgo = 0, // This will be set later when decrypting
+                            hashAlgo = 0, // This will be set later when decrypting
+                            keyIndex = 0, // This will be set later when decrypting
+                            updateTime = System.currentTimeMillis(),
+                            data = model.data
+                        )
+                        restoreViewModel.addWalletInfo(backupItem.userName, backupItem.address)
+                        restoreViewModel.toPinCode(backupItem.data)
                     }
                 }
             }

--- a/app/src/main/java/com/flowfoundation/wallet/page/restore/multirestore/fragment/RestoreGoogleDriveFragment.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/restore/multirestore/fragment/RestoreGoogleDriveFragment.kt
@@ -24,7 +24,6 @@ import com.flowfoundation.wallet.base.recyclerview.BaseViewHolder
 import com.flowfoundation.wallet.base.recyclerview.getItemView
 import com.flowfoundation.wallet.databinding.FragmentRestoreGoogleDriveBinding
 import com.flowfoundation.wallet.manager.backup.ACTION_GOOGLE_DRIVE_RESTORE_FINISH
-import com.flowfoundation.wallet.manager.backup.BackupItem
 import com.flowfoundation.wallet.manager.drive.DriveItem
 import com.flowfoundation.wallet.manager.drive.EXTRA_CONTENT
 import com.flowfoundation.wallet.manager.drive.GoogleDriveAuthActivity

--- a/app/src/main/java/com/flowfoundation/wallet/page/restore/multirestore/viewmodel/MultiRestoreViewModel.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/restore/multirestore/viewmodel/MultiRestoreViewModel.kt
@@ -14,6 +14,7 @@ import com.flowfoundation.wallet.manager.account.Account
 import com.flowfoundation.wallet.manager.account.AccountManager
 import com.flowfoundation.wallet.manager.account.DeviceInfoManager
 import com.flowfoundation.wallet.manager.backup.BackupCryptoProvider
+import com.flowfoundation.wallet.manager.drive.DriveItem
 import com.flowfoundation.wallet.manager.flowjvm.CadenceArgumentsBuilder
 import com.flowfoundation.wallet.manager.flowjvm.CadenceScript
 import com.flowfoundation.wallet.manager.flowjvm.addPlatformInfo
@@ -71,6 +72,7 @@ class MultiRestoreViewModel : ViewModel(), OnTransactionStateChange {
     private val mnemonicList = mutableListOf<String>()
     private var currentTxId: String? = null
     private var mnemonicData = ""
+    private var driveItems: List<DriveItem> = emptyList()
 
     init {
         TransactionStateManager.addOnTransactionStateChange(this)
@@ -367,5 +369,13 @@ class MultiRestoreViewModel : ViewModel(), OnTransactionStateChange {
                 syncAccountInfo()
             }
         }
+    }
+
+    fun setDriveItems(items: List<DriveItem>) {
+        driveItems = items
+    }
+
+    fun getDriveItems(): List<DriveItem> {
+        return driveItems
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->
Closes https://github.com/onflow/FRW-Android/issues/739

## Summary of Changes
<!-- Provide a concise description of the changes made in this PR. 
What functionality was added, updated, or fixed? -->

Problem: 
- The code was trying to cast a DriveItem to a BackupItem directly
- This was causing a crash because DriveItem and BackupItem are different classes with different structures

Changes made: 
- Store the original DriveItem objects in the ViewModel using setDriveItems()
- Only display the usernames from the DriveItem objects in the list
- When a user selects an account,  find the corresponding DriveItem and use its encrypted data for the password entry step
- The actual conversion to BackupItem happens later after decryption


## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [x] Yes
- [ ] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [ ] Low
- [ ] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
