### PR TITLE
fix: restore the constructor of the account proof encode method

### DIFF
--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectResponse.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectResponse.kt
@@ -122,6 +122,7 @@ private fun accountProof(address: String, keyId: Int, nonce: String?, appIdentif
     val accountProofSign = cryptoProvider.signData(encodeAccountProof(
         address,
         nonce,
+        appIdentifier,
         includeDomainTag = true
     ))
     return """

--- a/app/src/main/java/com/flowfoundation/wallet/widgets/webview/fcl/Utils.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/widgets/webview/fcl/Utils.kt
@@ -2,9 +2,12 @@ package com.flowfoundation.wallet.widgets.webview.fcl
 
 import android.webkit.WebView
 import com.nftco.flow.sdk.DomainTag
+import com.nftco.flow.sdk.hexToBytes
+import com.flowfoundation.wallet.wallet.toAddress
 import com.flowfoundation.wallet.widgets.webview.fcl.model.FclAuthnResponse
 import com.flowfoundation.wallet.widgets.webview.fcl.model.FclAuthzResponse
 import com.flowfoundation.wallet.widgets.webview.fcl.model.FclDialogModel
+import org.tdf.rlp.RLP
 import org.tdf.rlp.RLPCodec
 
 private val accountProofTag = DomainTag.normalize("FCL-ACCOUNT-PROOF-V0.0")
@@ -12,26 +15,31 @@ private val accountProofTag = DomainTag.normalize("FCL-ACCOUNT-PROOF-V0.0")
 // encode flow jvm account proof
 fun FclAuthnResponse.encodeAccountProof(address: String, includeDomainTag: Boolean = true): ByteArray {
     val nonce = body.nonce ?: return byteArrayOf()
-    body.appIdentifier ?: throw IllegalStateException("Encode Message For Provable Authn Error: appIdentifier must be defined")
-    return encodeAccountProof(address, nonce, includeDomainTag)
+    val appIdentifier = body.appIdentifier ?: throw IllegalStateException("Encode Message For Provable Authn Error: appIdentifier must be defined")
+    return encodeAccountProof(address, nonce, appIdentifier, includeDomainTag)
 }
 
 fun encodeAccountProof(
     address: String,
     nonce: String,
+    appIdentifier: String,
     includeDomainTag: Boolean,
 ): ByteArray {
     assert(address.isNotBlank()) { "Encode Message For Provable Authn Error: address must be defined" }
     assert(nonce.length >= 64) { "Encode Message For Provable Authn Error: nonce must be minimum of 32 bytes" }
 
-    val rpl = RLPCodec.encode(AccountProof())
+    val rpl = RLPCodec.encode(AccountProof(appIdentifier, address.toAddress().hexToBytes(), nonce.hexToBytes()))
 
     return if (includeDomainTag) {
         accountProofTag + rpl
     } else rpl
 }
 
-private class AccountProof
+private class AccountProof(
+    @RLP(0) val appIdentifier: String,
+    @RLP(1) val address: ByteArray,
+    @RLP(2) val nonce: ByteArray,
+)
 
 fun FclAuthzResponse.toFclDialogModel(webView: WebView): FclDialogModel {
     return FclDialogModel(


### PR DESCRIPTION
## Related Issue
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->
Closes #886 

## Summary of Changes
<!-- Provide a concise description of the changes made in this PR. 
What functionality was added, updated, or fixed? -->

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [x] Yes
- [ ] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [ ] Low
- [ ] Medium
- [x] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
