### PR TITLE
Wallet Connect external browser redirect

### DIFF
--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnect.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnect.kt
@@ -11,6 +11,7 @@ import com.flowfoundation.wallet.utils.ioScope
 import com.flowfoundation.wallet.utils.logd
 import com.flowfoundation.wallet.utils.loge
 import com.flowfoundation.wallet.utils.safeRun
+import com.flowfoundation.wallet.utils.uiScope
 import com.reown.android.internal.common.scope
 import com.reown.android.relay.WSSConnectionState
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -21,7 +22,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlin.math.max
+import android.widget.Toast
+import android.view.Gravity
+import com.flowfoundation.wallet.R
+import com.flowfoundation.wallet.base.activity.BaseActivity
 
 private val TAG = WalletConnect::class.java.simpleName
 
@@ -42,6 +46,17 @@ class WalletConnect {
 
     fun pair(uri: String) {
         logd(TAG, "CoreClient.Relay isConnectionAvailable :${isConnectionAvailable.value}")
+        
+        // Show connecting toast immediately when pairing starts
+        val activity = BaseActivity.getCurrentActivity()
+        if (activity != null) {
+            uiScope {
+                val toast = Toast.makeText(activity, R.string.connecting, Toast.LENGTH_LONG)
+                toast.setGravity(Gravity.TOP or Gravity.CENTER_HORIZONTAL, 0, 0)
+                toast.show()
+            }
+        }
+
         if (!isConnectionAvailable.value) {
             var job: kotlinx.coroutines.Job? = null
             job = ioScope {
@@ -50,14 +65,12 @@ class WalletConnect {
                 isConnectionAvailable.collect { isConnected ->
                     if (isConnected) {
                         delay(1000)
-                        logd(TAG, "Pair on connected")
                         try {
                             val pairingParams = Core.Params.Pair(uri)
                             logd(TAG, "Attempting to pair with params: $pairingParams")
                             CoreClient.Pairing.pair(pairingParams) { error ->
                                 loge(TAG, "Pairing error: ${error.throwable}")
                             }
-                            logd(TAG, "Pairing completed, checking for active sessions")
                             val sessions = SignClient.getListOfActiveSessions()
                             logd(TAG, "Active sessions: ${sessions.size}")
                         } catch (e: Exception) {
@@ -69,14 +82,12 @@ class WalletConnect {
                     } else {
                         attempts++
                         if (attempts >= maxAttempts) {
-                            logd(TAG, "Pair on max attempts")
                             try {
                                 val pairingParams = Core.Params.Pair(uri)
                                 logd(TAG, "Attempting to pair with params: $pairingParams")
                                 CoreClient.Pairing.pair(pairingParams) { error ->
                                     loge(TAG, "Pairing error: ${error.throwable}")
                                 }
-                                logd(TAG, "Pairing completed, checking for active sessions")
                                 val sessions = SignClient.getListOfActiveSessions()
                                 logd(TAG, "Active sessions: ${sessions.size}")
                             } catch (e: Exception) {
@@ -99,11 +110,9 @@ class WalletConnect {
         } else {
             try {
                 val pairingParams = Core.Params.Pair(uri)
-                logd(TAG, "Attempting to pair with params: $pairingParams")
                 CoreClient.Pairing.pair(pairingParams) { error ->
                     loge(TAG, "Pairing error: ${error.throwable}")
                 }
-                logd(TAG, "Pairing completed, checking for active sessions")
                 val sessions = SignClient.getListOfActiveSessions()
                 logd(TAG, "Active sessions: ${sessions.size}")
             } catch (e: Exception) {
@@ -160,7 +169,7 @@ private fun setup(application: Application) {
         description = "Digital wallet created for everyone.",
         url = "https://core.flow.com/",
         icons = listOf("https://lilico.app/fcw-logo.png"),
-        redirect = "flowwallet://wc",
+        redirect = null,
     )
     CoreClient.initialize(
         application = application,

--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnect.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnect.kt
@@ -51,15 +51,36 @@ class WalletConnect {
                     if (isConnected) {
                         delay(1000)
                         logd(TAG, "Pair on connected")
-                        paring(uri)
-                        job?.cancel()
+                        try {
+                            val pairingParams = Core.Params.Pair(uri)
+                            logd(TAG, "Attempting to pair with params: $pairingParams")
+                            CoreClient.Pairing.pair(pairingParams) { error ->
+                                loge(TAG, "Pairing error: ${error.throwable}")
+                            }
+                            logd(TAG, "Pairing completed, checking for active sessions")
+                            val sessions = SignClient.getListOfActiveSessions()
+                            logd(TAG, "Active sessions: ${sessions.size}")
+                        } catch (e: Exception) {
+                            loge(TAG, "Pairing exception: ${e.message}")
+                            loge(e)
+                        } finally {
+                            job?.cancel()
+                        }
                     } else {
                         attempts++
                         if (attempts >= maxAttempts) {
                             logd(TAG, "Pair on max attempts")
                             try {
-                                paring(uri)
+                                val pairingParams = Core.Params.Pair(uri)
+                                logd(TAG, "Attempting to pair with params: $pairingParams")
+                                CoreClient.Pairing.pair(pairingParams) { error ->
+                                    loge(TAG, "Pairing error: ${error.throwable}")
+                                }
+                                logd(TAG, "Pairing completed, checking for active sessions")
+                                val sessions = SignClient.getListOfActiveSessions()
+                                logd(TAG, "Active sessions: ${sessions.size}")
                             } catch (e: Exception) {
+                                loge(TAG, "Pairing exception: ${e.message}")
                                 loge(e)
                             } finally {
                                 job?.cancel()
@@ -76,18 +97,19 @@ class WalletConnect {
                 }
             }
         } else {
-            paring(uri)
-        }
-    }
-
-    private fun paring(uri: String) {
-        try {
-            val pairingParams = Core.Params.Pair(uri)
-            CoreClient.Pairing.pair(pairingParams) { error ->
-                loge(error.throwable)
+            try {
+                val pairingParams = Core.Params.Pair(uri)
+                logd(TAG, "Attempting to pair with params: $pairingParams")
+                CoreClient.Pairing.pair(pairingParams) { error ->
+                    loge(TAG, "Pairing error: ${error.throwable}")
+                }
+                logd(TAG, "Pairing completed, checking for active sessions")
+                val sessions = SignClient.getListOfActiveSessions()
+                logd(TAG, "Active sessions: ${sessions.size}")
+            } catch (e: Exception) {
+                loge(TAG, "Pairing exception: ${e.message}")
+                loge(e)
             }
-        } catch (e: Exception) {
-            loge(e)
         }
     }
 
@@ -138,7 +160,7 @@ private fun setup(application: Application) {
         description = "Digital wallet created for everyone.",
         url = "https://core.flow.com/",
         icons = listOf("https://lilico.app/fcw-logo.png"),
-        redirect = null,
+        redirect = "flowwallet://wc",
     )
     CoreClient.initialize(
         application = application,

--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectDelegate.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectDelegate.kt
@@ -9,7 +9,6 @@ import com.reown.sign.client.Sign
 import com.reown.sign.client.SignClient
 import com.flowfoundation.wallet.manager.walletconnect.model.toWcRequest
 import com.flowfoundation.wallet.page.wallet.dialog.MoveDialog
-import com.flowfoundation.wallet.utils.debug.toast
 import com.flowfoundation.wallet.utils.extensions.openInSystemBrowser
 import com.flowfoundation.wallet.utils.ioScope
 import com.flowfoundation.wallet.utils.isShowMoveDialog

--- a/app/src/main/java/com/flowfoundation/wallet/page/component/deeplinking/DeepLinkingActivity.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/component/deeplinking/DeepLinkingActivity.kt
@@ -6,7 +6,10 @@ import android.view.View
 import com.flowfoundation.wallet.base.activity.BaseActivity
 import com.zackratos.ultimatebarx.ultimatebarx.UltimateBarX
 import com.flowfoundation.wallet.page.main.MainActivity
+import com.flowfoundation.wallet.utils.ioScope
 import com.flowfoundation.wallet.utils.logd
+import com.flowfoundation.wallet.utils.loge
+import kotlinx.coroutines.launch
 
 private val TAG = DeepLinkingActivity::class.java.simpleName
 
@@ -23,14 +26,24 @@ class DeepLinkingActivity : BaseActivity() {
             return
         }
 
-        logd(TAG, "uri:$uri")
+        logd(TAG, "DeepLinkingActivity received uri: $uri")
         MainActivity.launch(this)
-        dispatchDeepLinking(this, uri)
-        finish()
+        
+        ioScope {
+            try {
+                dispatchDeepLinking(this@DeepLinkingActivity, uri)
+                logd(TAG, "DeepLinkingDispatch completed for uri: $uri")
+            } catch (e: Exception) {
+                logd(TAG, "Error in DeepLinkingDispatch: ${e.message}")
+                loge(e)
+            } finally {
+                finish()
+            }
+        }
     }
 
     override fun onPause() {
         super.onPause()
-        finish()
+        // Don't finish here, let the coroutine handle it
     }
 }

--- a/app/src/main/java/com/flowfoundation/wallet/page/component/deeplinking/PendingActionHelper.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/component/deeplinking/PendingActionHelper.kt
@@ -3,6 +3,7 @@ package com.flowfoundation.wallet.page.component.deeplinking
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.Uri
+import com.flowfoundation.wallet.utils.logd
 
 
 object PendingActionHelper {
@@ -15,6 +16,7 @@ object PendingActionHelper {
     }
 
     fun savePendingDeepLink(context: Context, deepLink: Uri) {
+        logd("DeepLinkingDispatch", "executeDeepLinking: savePendingDeepLink")
         getPrefs(context).edit().apply {
             putString(KEY_PENDING_DEEPLINK, deepLink.toString())
             putBoolean(KEY_HAS_PENDING_DEEPLINK, true)

--- a/app/src/main/java/com/flowfoundation/wallet/page/component/deeplinking/Utils.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/component/deeplinking/Utils.kt
@@ -2,7 +2,6 @@ package com.flowfoundation.wallet.page.component.deeplinking
 
 import android.content.Context
 import android.net.Uri
-import android.util.Log
 import com.flowfoundation.wallet.R
 import com.flowfoundation.wallet.base.activity.BaseActivity
 import com.flowfoundation.wallet.firebase.auth.isUserSignIn
@@ -23,11 +22,7 @@ import com.flowfoundation.wallet.utils.uiScope
 import com.flowfoundation.wallet.wallet.toAddress
 import com.flowfoundation.wallet.widgets.DialogType
 import com.flowfoundation.wallet.widgets.SwitchNetworkDialog
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.time.withTimeoutOrNull
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.web3j.utils.Convert
 import org.web3j.utils.Numeric

--- a/app/src/main/java/com/flowfoundation/wallet/page/component/deeplinking/Utils.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/component/deeplinking/Utils.kt
@@ -147,7 +147,6 @@ private suspend fun dispatchWalletConnect(uri: Uri): Boolean {
                         WalletConnect.get().pair(data.toString())
                         logd(TAG, "WalletConnect pairing successful")
                         // Wait for session proposal to be handled
-                        delay(2000) // Increased delay to ensure proposal is processed
                         result = true
                     } catch (e: Exception) {
                         loge(TAG, "WalletConnect pairing failed: ${e.message}")
@@ -163,7 +162,6 @@ private suspend fun dispatchWalletConnect(uri: Uri): Boolean {
                 WalletConnect.get().pair(data.toString())
                 logd(TAG, "WalletConnect pairing successful")
                 // Wait for session proposal to be handled
-                delay(2000) // Increased delay to ensure proposal is processed
                 true
             } catch (e: Exception) {
                 loge(TAG, "WalletConnect pairing failed: ${e.message}")

--- a/app/src/main/java/com/flowfoundation/wallet/widgets/webview/fcl/dialog/FclAuthnDialog.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/widgets/webview/fcl/dialog/FclAuthnDialog.kt
@@ -72,12 +72,6 @@ class FclAuthnDialog : BottomSheetDialogFragment() {
                 flBlockedConnect.setOnClickListener {
                     result?.resume(true)
                     dismiss()
-                    // Redirect to external browser after approval
-                    data.url?.let { url ->
-                        uiScope {
-                            url.openInSystemBrowser(requireContext(), true)
-                        }
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/flowfoundation/wallet/widgets/webview/fcl/dialog/FclAuthnDialog.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/widgets/webview/fcl/dialog/FclAuthnDialog.kt
@@ -13,12 +13,10 @@ import com.flowfoundation.wallet.manager.app.chainNetWorkString
 import com.flowfoundation.wallet.manager.blocklist.BlockManager
 import com.flowfoundation.wallet.manager.emoji.AccountEmojiManager
 import com.flowfoundation.wallet.manager.emoji.model.Emoji
-import com.flowfoundation.wallet.manager.evm.EVMWalletManager
 import com.flowfoundation.wallet.manager.wallet.WalletManager
 import com.flowfoundation.wallet.page.browser.loadFavicon
 import com.flowfoundation.wallet.page.browser.toFavIcon
 import com.flowfoundation.wallet.utils.extensions.capitalizeV2
-import com.flowfoundation.wallet.utils.extensions.openInSystemBrowser
 import com.flowfoundation.wallet.utils.extensions.setVisible
 import com.flowfoundation.wallet.utils.extensions.urlHost
 import com.flowfoundation.wallet.utils.uiScope

--- a/app/src/main/java/com/flowfoundation/wallet/widgets/webview/fcl/dialog/FclAuthnDialog.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/widgets/webview/fcl/dialog/FclAuthnDialog.kt
@@ -18,6 +18,7 @@ import com.flowfoundation.wallet.manager.wallet.WalletManager
 import com.flowfoundation.wallet.page.browser.loadFavicon
 import com.flowfoundation.wallet.page.browser.toFavIcon
 import com.flowfoundation.wallet.utils.extensions.capitalizeV2
+import com.flowfoundation.wallet.utils.extensions.openInSystemBrowser
 import com.flowfoundation.wallet.utils.extensions.setVisible
 import com.flowfoundation.wallet.utils.extensions.urlHost
 import com.flowfoundation.wallet.utils.uiScope
@@ -71,6 +72,12 @@ class FclAuthnDialog : BottomSheetDialogFragment() {
                 flBlockedConnect.setOnClickListener {
                     result?.resume(true)
                     dismiss()
+                    // Redirect to external browser after approval
+                    data.url?.let { url ->
+                        uiScope {
+                            url.openInSystemBrowser(requireContext(), true)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,6 +226,7 @@
     <string name="made_by_outblock">Made by <a href="https://flow.com/">Flow</a></string>
     <string name="about_version">Version %1$s</string>
     <string name="connecting_to">Connecting to</string>
+    <string name="connecting">Connecting...</string>
     <string name="transaction_to">Transaction Request from</string>
     <string name="message_to">Sign Message Request from</string>
     <string name="fcl_connect_permission_title">This App would like to</string>
@@ -745,4 +746,5 @@
     <string name="blocked_tip">This app has been flagged as dangerous.</string>
     <string name="switch_to">Switch to %1$s</string>
     <string name="deeplink_login_failed">Failed to open, please create a wallet first.</string>
+    <string name="return_to_browser_to_continue">Please return to the browser to continue your session.</string>
 </resources>


### PR DESCRIPTION
## Related Issue
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->


- When WalletConnect connection request via deep link is missing redirect URL,handle the session connection and show a toast fallback indicating to return back to the browser
- Add a "Connecting..." toast which is shown from the beginning of the deep linking flow until the FCL Auth Dialog is fully rendered
- 

## Summary of Changes
<!-- Provide a concise description of the changes made in this PR. 
What functionality was added, updated, or fixed? -->

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [ ] Yes
- [ ] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [ ] Low
- [ ] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
