### PR TITLE
Update payer signing logic

### DIFF
--- a/app/src/main/java/com/flowfoundation/wallet/manager/flowjvm/transaction/Signable.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/flowjvm/transaction/Signable.kt
@@ -18,6 +18,19 @@ data class Signable(
     val message: String? = null,
     @SerializedName("voucher")
     var voucher: Voucher? = null,
+    @SerializedName("roles")
+    val roles: SignableRoles? = null,
+)
+
+data class SignableRoles(
+    @SerializedName("proposer")
+    val proposer: Boolean = false,
+    @SerializedName("authorizer")
+    val authorizer: Boolean = false,
+    @SerializedName("payer")
+    val payer: Boolean = false,
+    @SerializedName("param")
+    val param: Boolean = false,
 )
 
 data class AsArgument(

--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnect.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnect.kt
@@ -105,13 +105,13 @@ class WalletConnect {
                 }
                 
                 // Clean up all active sessions before pairing
-                try {
-                    cleanupActiveSessions()
-                } catch (e: Exception) {
-                    loge(TAG, "Error cleaning up sessions before pairing: ${e.message}")
-                    loge(e)
-                    // Continue with pairing anyway
-                }
+//                try {
+//                    cleanupActiveSessions()
+//                } catch (e: Exception) {
+//                    loge(TAG, "Error cleaning up sessions before pairing: ${e.message}")
+//                    loge(e)
+//                    // Continue with pairing anyway
+//                }
 
                 // Add a short delay to ensure cleanup has time to complete
                 delay(500)

--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectDelegate.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectDelegate.kt
@@ -57,26 +57,26 @@ internal class WalletConnectDelegate : SignClient.WalletDelegate {
                         delay(1000L * (reconnectAttempts + 1))
                         logd(TAG, "Reconnection attempt ${reconnectAttempts + 1} of $maxReconnectAttempts")
                         
-                        // Only clean up sessions if we're not processing a request
-                        if (!isProcessingRequest) {
-                            try {
-                                val activeSessions = SignClient.getListOfActiveSessions()
-                                logd(TAG, "Cleaning up stale sessions. Current count: ${activeSessions.size}")
-                                activeSessions.forEach { session ->
-                                    if (session.metaData == null && session.topic != lastActiveTopic) {
-                                        logd(TAG, "Disconnecting stale session: ${session.topic}")
-                                        SignClient.disconnect(Sign.Params.Disconnect(sessionTopic = session.topic)) { error ->
-                                            loge(TAG, "Error disconnecting stale session: ${error.throwable}")
-                                        }
-                                    }
-                                }
-                            } catch (e: Exception) {
-                                loge(TAG, "Error cleaning up sessions: ${e.message}")
-                                loge(e)
-                            }
-                        } else {
-                            logd(TAG, "Skipping session cleanup while processing request")
-                        }
+//                        // Only clean up sessions if we're not processing a request
+//                        if (!isProcessingRequest) {
+//                            try {
+//                                val activeSessions = SignClient.getListOfActiveSessions()
+//                                logd(TAG, "Cleaning up stale sessions. Current count: ${activeSessions.size}")
+//                                activeSessions.forEach { session ->
+//                                    if (session.metaData == null && session.topic != lastActiveTopic) {
+//                                        logd(TAG, "Disconnecting stale session: ${session.topic}")
+//                                        SignClient.disconnect(Sign.Params.Disconnect(sessionTopic = session.topic)) { error ->
+//                                            loge(TAG, "Error disconnecting stale session: ${error.throwable}")
+//                                        }
+//                                    }
+//                                }
+//                            } catch (e: Exception) {
+//                                loge(TAG, "Error cleaning up sessions: ${e.message}")
+//                                loge(e)
+//                            }
+//                        } else {
+//                            logd(TAG, "Skipping session cleanup while processing request")
+//                        }
                         
                         CoreClient.Relay.connect { error: Core.Model.Error ->
                             loge(TAG, "CoreClient.Relay connect error: $error")
@@ -127,21 +127,21 @@ internal class WalletConnectDelegate : SignClient.WalletDelegate {
             val errorMessage = when {
                 error.throwable.message?.contains("No proposal or pending session") == true -> {
                     // Clean up any stale sessions when we get this error
-                    try {
-                        val activeSessions = SignClient.getListOfActiveSessions()
-                        logd(TAG, "Cleaning up stale sessions. Current count: ${activeSessions.size}")
-                        activeSessions.forEach { session ->
-                            if (session.metaData == null) {
-                                logd(TAG, "Disconnecting stale session: ${session.topic}")
-                                SignClient.disconnect(Sign.Params.Disconnect(sessionTopic = session.topic)) { disconnectError ->
-                                    loge(TAG, "Error disconnecting stale session: ${disconnectError.throwable}")
-                                }
-                            }
-                        }
-                    } catch (e: Exception) {
-                        loge(TAG, "Error cleaning up sessions: ${e.message}")
-                        loge(e)
-                    }
+//                    try {
+//                        val activeSessions = SignClient.getListOfActiveSessions()
+//                        logd(TAG, "Cleaning up stale sessions. Current count: ${activeSessions.size}")
+//                        activeSessions.forEach { session ->
+//                            if (session.metaData == null) {
+//                                logd(TAG, "Disconnecting stale session: ${session.topic}")
+//                                SignClient.disconnect(Sign.Params.Disconnect(sessionTopic = session.topic)) { disconnectError ->
+//                                    loge(TAG, "Error disconnecting stale session: ${disconnectError.throwable}")
+//                                }
+//                            }
+//                        }
+//                    } catch (e: Exception) {
+//                        loge(TAG, "Error cleaning up sessions: ${e.message}")
+//                        loge(e)
+//                    }
                     R.string.wallet_connect_no_proposal
                 }
                 error.throwable.message?.contains("pairing topic") == true -> {

--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectRequestDispatcher.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectRequestDispatcher.kt
@@ -94,7 +94,6 @@ suspend fun WCRequest.dispatch() {
         WalletConnectMethod.EVM_SIGN_MESSAGE.value -> evmSignMessage()
         WalletConnectMethod.EVM_SEND_TRANSACTION.value -> evmSendTransaction()
         WalletConnectMethod.EVM_SIGN_TYPED_DATA.value, WalletConnectMethod.EVM_SIGN_TYPED_DATA_V3.value,
-        WalletConnectMethod.EVM_SIGN_TYPED_DATA.value, WalletConnectMethod.EVM_SIGN_TYPED_DATA_V3.value,
         WalletConnectMethod.EVM_SIGN_TYPED_DATA_V4.value -> evmSignTypedData()
         WalletConnectMethod.WALLET_WATCH_ASSETS.value -> watchAssets()
         else -> {

--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectRequestDispatcher.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectRequestDispatcher.kt
@@ -81,59 +81,22 @@ suspend fun WCRequest.dispatch() {
     logd(TAG, "Supported Flow methods: ${WalletConnectMethod.getSupportedFlowMethod()}")
     
     when (method) {
-        WalletConnectMethod.AUTHN.value -> {
-            logd(TAG, "Dispatching to respondAuthn")
-            respondAuthn()
-        }
-        WalletConnectMethod.AUTHZ.value -> {
-            logd(TAG, "Dispatching to respondAuthz")
-            respondAuthz()
-        }
-        WalletConnectMethod.PRE_AUTHZ.value -> {
-            logd(TAG, "Dispatching to respondPreAuthz")
-            respondPreAuthz()
-        }
-        WalletConnectMethod.USER_SIGNATURE.value -> {
-            logd(TAG, "Dispatching to respondUserSign")
-            respondUserSign()
-        }
-        WalletConnectMethod.SIGN_PROPOSER.value -> {
-            logd(TAG, "Dispatching to respondSignProposer")
-            respondSignProposer()
-        }
-        WalletConnectMethod.ACCOUNT_INFO.value -> {
-            logd(TAG, "Dispatching to respondAccountInfo")
-            respondAccountInfo()
-        }
-        WalletConnectMethod.ADD_DEVICE_KEY.value -> {
-            logd(TAG, "Dispatching to respondAddDeviceKey")
-            respondAddDeviceKey()
-        }
-        WalletConnectMethod.PROXY_ACCOUNT.value -> {
-            logd(TAG, "Dispatching to respondProxyAccount")
-            respondProxyAccount()
-        }
-        WalletConnectMethod.PROXY_SIGN.value -> {
-            logd(TAG, "Dispatching to respondProxySign")
-            respondProxySign()
-        }
-        WalletConnectMethod.EVM_SIGN_MESSAGE.value -> {
-            logd(TAG, "Dispatching to evmSignMessage")
-            evmSignMessage()
-        }
-        WalletConnectMethod.EVM_SEND_TRANSACTION.value -> {
-            logd(TAG, "Dispatching to evmSendTransaction")
-            evmSendTransaction()
-        }
+        WalletConnectMethod.AUTHN.value -> respondAuthn()
+        WalletConnectMethod.AUTHZ.value -> respondAuthz()
+        WalletConnectMethod.PRE_AUTHZ.value -> respondPreAuthz()
+        WalletConnectMethod.USER_SIGNATURE.value -> respondUserSign()
+        // WalletConnectMethod.SIGN_PAYER.value -> respondSignPayer()
+        WalletConnectMethod.SIGN_PROPOSER.value -> respondSignProposer()
+        WalletConnectMethod.ACCOUNT_INFO.value -> respondAccountInfo()
+        WalletConnectMethod.ADD_DEVICE_KEY.value -> respondAddDeviceKey()
+        WalletConnectMethod.PROXY_ACCOUNT.value -> respondProxyAccount()
+        WalletConnectMethod.PROXY_SIGN.value -> respondProxySign()
+        WalletConnectMethod.EVM_SIGN_MESSAGE.value -> evmSignMessage()
+        WalletConnectMethod.EVM_SEND_TRANSACTION.value -> evmSendTransaction()
         WalletConnectMethod.EVM_SIGN_TYPED_DATA.value, WalletConnectMethod.EVM_SIGN_TYPED_DATA_V3.value,
-        WalletConnectMethod.EVM_SIGN_TYPED_DATA_V4.value -> {
-            logd(TAG, "Dispatching to evmSignTypedData")
-            evmSignTypedData()
-        }
-        WalletConnectMethod.WALLET_WATCH_ASSETS.value -> {
-            logd(TAG, "Dispatching to watchAssets")
-            watchAssets()
-        }
+        WalletConnectMethod.EVM_SIGN_TYPED_DATA.value, WalletConnectMethod.EVM_SIGN_TYPED_DATA_V3.value,
+        WalletConnectMethod.EVM_SIGN_TYPED_DATA_V4.value -> evmSignTypedData()
+        WalletConnectMethod.WALLET_WATCH_ASSETS.value -> watchAssets()
         else -> {
             loge(TAG, "Unknown method: $method")
             loge(TAG, "Available methods: ${WalletConnectMethod.values().map { it.value }}")

--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectRequestDispatcher.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectRequestDispatcher.kt
@@ -76,10 +76,6 @@ import kotlin.coroutines.suspendCoroutine
 private const val TAG = "WalletConnectRequestDispatcher"
 
 suspend fun WCRequest.dispatch() {
-    logd(TAG, "dispatch() called for method: $method")
-    logd(TAG, "Request details - ID: $requestId, Topic: $topic")
-    logd(TAG, "Supported Flow methods: ${WalletConnectMethod.getSupportedFlowMethod()}")
-    
     when (method) {
         WalletConnectMethod.AUTHN.value -> respondAuthn()
         WalletConnectMethod.AUTHZ.value -> respondAuthz()

--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectRequestDispatcher.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/WalletConnectRequestDispatcher.kt
@@ -383,8 +383,7 @@ private suspend fun WCRequest.respondAuthz() {
     val address = WalletManager.wallet()?.walletAddress() ?: return
     val cryptoProvider = CryptoProviderManager.getCurrentCryptoProvider() ?: return
     
-    // Check if this is a payer-only request (like iOS implementation)
-    // Roles can be null, so we need to check safely
+    // Check if this is a payer-only request
     val roles = signable.roles
     if (roles != null && roles.payer && !roles.proposer && !roles.authorizer) {
         logd(TAG, "Handling payer-only signing request")

--- a/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/model/WalletConnectMethod.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/walletconnect/model/WalletConnectMethod.kt
@@ -23,9 +23,25 @@ enum class WalletConnectMethod(val value: String) {
 
         @JvmStatic
         fun getSupportedFlowMethod(): List<String> {
-            return listOf(AUTHN.value, AUTHZ.value, PRE_AUTHZ.value, SIGN_PAYER.value,
-                SIGN_PROPOSER.value, USER_SIGNATURE.value, ACCOUNT_PROOF.value, ACCOUNT_INFO
-                    .value, ADD_DEVICE_KEY.value, PROXY_ACCOUNT.value, PROXY_SIGN.value)
+            return listOf(
+                AUTHN.value,
+                AUTHZ.value,
+                PRE_AUTHZ.value,
+                SIGN_PROPOSER.value,
+                USER_SIGNATURE.value,
+                ACCOUNT_PROOF.value,
+                *getFRWMethod().toTypedArray()
+            )
+        }
+
+        @JvmStatic
+        fun getFRWMethod(): List<String> {
+            return listOf(
+                ACCOUNT_INFO.value,
+                ADD_DEVICE_KEY.value,
+                PROXY_ACCOUNT.value,
+                PROXY_SIGN.value
+            )
         }
 
         @JvmStatic


### PR DESCRIPTION
## Related Issue
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->
https://github.com/onflow/FRW-Android/issues/1150
https://github.com/onflow/FRW-Android/issues/1146

- Update WC payer signing logic to match that used in iOS implementation : https://github.com/onflow/FRW-iOS/blob/develop/FRW/Services/Manager/WalletConnect/WalletConnectManager.swift. iOS handles all signing (including payer) through the `authz` method with role-based logic, instead of `flow_sign_payer`
- Disable WC session cleanup logic for now as this might be causing other issues


## Summary of Changes


https://github.com/user-attachments/assets/ee564f82-4e3d-43f1-bf5a-ceb02a323ee5


## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [ ] Yes
- [ ] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [ ] Low
- [ ] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
