### PR TITLE
Move max button UI changes

### DIFF
--- a/app/src/main/java/com/flowfoundation/wallet/manager/account/WalletFetcher.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/account/WalletFetcher.kt
@@ -24,6 +24,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.concurrent.scheduleAtFixedRate
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.Lifecycle
+import com.flowfoundation.wallet.firebase.auth.firebaseUid
 
 object WalletFetcher {
     private val TAG = WalletFetcher::class.java.simpleName
@@ -122,8 +123,11 @@ object WalletFetcher {
                             blockchain = listOf(blockchainData),
                             name = "Flow Wallet"
                         )
+                        val firebaseUserId = firebaseUid()
+                            ?: throw IllegalStateException("Firebase user ID is null - cannot create wallet data")
+                        
                         val walletListData = WalletListData(
-                            id = currentAccount.userInfo.username,
+                            id = firebaseUserId,
                             username = currentAccount.userInfo.username,
                             wallets = listOf(walletData)
                         )

--- a/app/src/main/java/com/flowfoundation/wallet/manager/wallet/WalletManager.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/manager/wallet/WalletManager.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.withTimeout
 import org.onflow.flow.ChainId
 import org.onflow.flow.models.hexToBytes
 import java.util.concurrent.atomic.AtomicReference
+import com.flowfoundation.wallet.firebase.auth.firebaseUid
 
 object WalletManager {
     private val TAG = WalletManager::class.java.simpleName
@@ -215,8 +216,11 @@ object WalletManager {
                         name = chainId.toString()
                     )
                 }
+                val firebaseUserId = firebaseUid()
+                    ?: throw IllegalStateException("Firebase user ID is null - cannot create wallet data")
+                
                 account.wallet = WalletListData(
-                    id       = account.userInfo.username,         // or whatever id you use
+                    id       = firebaseUserId,
                     username = account.userInfo.username,
                     wallets  = wallets
                 )

--- a/app/src/main/java/com/flowfoundation/wallet/page/profile/subpage/developer/DeveloperModeViewModel.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/profile/subpage/developer/DeveloperModeViewModel.kt
@@ -17,6 +17,7 @@ import com.flowfoundation.wallet.utils.loge
 import com.flowfoundation.wallet.utils.logd
 import com.flowfoundation.wallet.utils.viewModelIOScope
 import org.onflow.flow.ChainId
+import com.flowfoundation.wallet.firebase.auth.firebaseUid
 
 class DeveloperModeViewModel : ViewModel() {
     val progressVisibleLiveData = MutableLiveData<Boolean>()
@@ -66,8 +67,11 @@ class DeveloperModeViewModel : ViewModel() {
                             blockchain = listOf(blockchainData),
                             name = "Flow Wallet"
                         )
+                        val firebaseUserId = firebaseUid()
+                            ?: throw IllegalStateException("Firebase user ID is null - cannot create wallet data")
+                        
                         val walletListData = WalletListData(
-                            id = currentAccount.userInfo.username,
+                            id = firebaseUserId,
                             username = currentAccount.userInfo.username,
                             wallets = listOf(walletData)
                         )

--- a/app/src/main/java/com/flowfoundation/wallet/page/token/detail/widget/MoveTokenDialog.kt
+++ b/app/src/main/java/com/flowfoundation/wallet/page/token/detail/widget/MoveTokenDialog.kt
@@ -300,8 +300,8 @@ class MoveTokenDialog : BottomSheetDialogFragment() {
                     if (token != null) {
                         updateSelectedToken(token)
                     } else {
-                        // Enable max button even if no specific token found, balance might be available
-                        binding.tvMax.isEnabled = fromBalance > BigDecimal.ZERO
+                        // Show max button only if balance is available
+                        binding.tvMax.setVisible(fromBalance > BigDecimal.ZERO)
                     }
                 }
             } else {


### PR DESCRIPTION
## Related Issue
<!-- If this PR addresses an issue, link it here (e.g., "Closes #123") -->
(2) When I click max button in move page, the maximum value wasn't displayed on the first click; it only appeared on the second click.


## Summary of Changes
<!-- Provide a concise description of the changes made in this PR. 
What functionality was added, updated, or fixed? -->
Move max button UI changes:
- Populate text field contents after first click of the button
- Hide max button when token balance is still loading/until it assumes a non-zero value

## Need Regression Testing
<!-- Indicate whether this PR requires regression testing and why. -->
- [ ] Yes
- [ ] No

## Risk Assessment
<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->
- [ ] Low
- [ ] Medium
- [ ] High

## Additional Notes
<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)
<!-- Attach any screenshots that help explain your changes -->
